### PR TITLE
fix(ci): Use correct pattern matching in workflow

### DIFF
--- a/.github/workflows/basic-build.yml
+++ b/.github/workflows/basic-build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - release/*
+      - release*
     paths-ignore:
       - '**/README*.md'
 


### PR DESCRIPTION
Uses correct pattern matching in build workflow to trigger it in all release branches

previously it was made to trigger on  only `release/` pattern